### PR TITLE
fix: Set token string from builder

### DIFF
--- a/src/commonMain/kotlin/io/github/hansanto/kault/auth/VaultAuth.kt
+++ b/src/commonMain/kotlin/io/github/hansanto/kault/auth/VaultAuth.kt
@@ -175,7 +175,7 @@ public class VaultAuth(
          * Set the [tokenInfo] builder from the provided token.
          * @param token Token to use for the next requests.
          */
-        public fun setToken(token: String) {
+        public fun setTokenString(token: String) {
             tokenInfo(TokenInfo(token))
         }
 

--- a/src/commonTest/kotlin/io/github/hansanto/kault/auth/VaultAuthTest.kt
+++ b/src/commonTest/kotlin/io/github/hansanto/kault/auth/VaultAuthTest.kt
@@ -107,7 +107,7 @@ class VaultAuthTest : ShouldSpec({
 
         val built = VaultAuth(client.client, parentPath) {
             path = builderPath
-            setToken(randomToken)
+            setTokenString(randomToken)
             appRole {
                 path = appRolePath
             }

--- a/src/commonTest/kotlin/io/github/hansanto/kault/util/VaultClientUtil.kt
+++ b/src/commonTest/kotlin/io/github/hansanto/kault/util/VaultClientUtil.kt
@@ -17,7 +17,7 @@ inline fun createVaultClient(
 ): VaultClient = VaultClient {
     url = "http://localhost:8200"
     auth {
-        setToken(ROOT_TOKEN)
+        setTokenString(ROOT_TOKEN)
         authBuilder()
     }
     httpClient { headerBuilder ->


### PR DESCRIPTION
# Checklist for this pull request

🚨 Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting your **branch** (right side).
- [ ] Make sure you are making a pull request against the **main branch** (left side).
- [ ] Check the commits message styles matches our [requested structure](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Check that documentation exists (comments, markdown, etc.).

## Description

The `VaultAuth` has 2 methods, `setTokenString` and `getTokenString`.
However, the class `VaultAuth.Builder` has the method `setToken`.

To keep the code consistent, the method `setToken` should be renamed to `setTokenString`.

### Before

```kotlin
VaultClient {
    auth {
        setToken("token")
    }
}
```

### After
```kotlin
VaultClient {
    auth {
        setTokenString("token")
    }
}
```

❤️ Thank you!
