### PR TITLE
fix: Publish on Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           jdk: 21
 
       - name: Build
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew deployCentralPortal
         env:
           REPOSITORY_USERNAME: ${{ secrets.REPOSITORY_USERNAME }}
           REPOSITORY_PASSWORD: ${{ secrets.REPOSITORY_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -189,20 +189,11 @@ kotlin {
     }
 }
 
-val dokkaOutputDir = file("dokka")
-
-val deleteDokkaOutputDir by tasks.register<Delete>("deleteDokkaOutputDirectory") {
-    group = JavaBasePlugin.DOCUMENTATION_GROUP
-    description = "Deletes the dokka output directory."
-    delete(dokkaOutputDir)
-}
-
-val javadocJar = tasks.register<Jar>("docJar") {
-    group = JavaBasePlugin.DOCUMENTATION_GROUP
+val javadocJar = tasks.register<Jar>("dokkaJavadocJar") {
+    group = "dokka"
     description = "Creates a jar containing the documentation."
-    dependsOn(deleteDokkaOutputDir, tasks.dokkaHtml)
     archiveClassifier.set("javadoc")
-    from(dokkaOutputDir)
+    dependsOn(tasks.dokkaGenerate)
 }
 
 tasks {
@@ -235,15 +226,6 @@ tasks {
         allprojects {
             this@register.dependsOn(tasks.withType<Detekt>())
         }
-    }
-
-    clean {
-        delete(dokkaOutputDir)
-    }
-
-    dokkaHtml.configure {
-        dependsOn(deleteDokkaOutputDir)
-        outputDirectory.set(file(dokkaOutputDir))
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -249,7 +249,9 @@ tasks {
 
 deployer {
     content {
-        kotlinComponents()
+        kotlinComponents {
+           docs(javadocJar)
+        }
     }
 
     localSpec()
@@ -262,55 +264,24 @@ deployer {
         signing.key.set(secret("SIGNING_KEY"))
         signing.password.set(secret("SIGNING_PASSWORD"))
     }
-}
 
-publishing {
-    publications {
+    projectInfo {
+        // https://opensource.deepmedia.io/deployer/configuration
         val projectName = project.name
         val projectOrganizationPath = "Hansanto/$projectName"
         val projectGitUrl = "https://github.com/$projectOrganizationPath"
 
-        withType<MavenPublication> {
-            artifact(javadocJar)
-            pom {
-                name.set(rootProject.name)
-                description.set(project.description)
-                url.set(projectGitUrl)
+        url.set(projectGitUrl)
 
-                issueManagement {
-                    system.set("GitHub")
-                    url.set("$projectGitUrl/issues")
-                }
+        scm {
+            fromGithub("Hansanto", projectName)
+        }
 
-                ciManagement {
-                    system.set("GitHub Actions")
-                }
-
-                licenses {
-                    license {
-                        name.set("Apache-2.0")
-                        url.set("https://www.apache.org/licenses/")
-                    }
-                }
-
-                developers {
-                    developer {
-                        name.set("Hansanto")
-                        email.set("anthony.hanson@outlook.fr")
-                        url.set("https://github.com/Hansanto")
-                    }
-                }
-
-                scm {
-                    connection.set("scm:git:$projectGitUrl.git")
-                    developerConnection.set("scm:git:git@github.com:$projectOrganizationPath.git")
-                    url.set(projectGitUrl)
-                }
-
-                distributionManagement {
-                    downloadUrl.set("$projectGitUrl/releases")
-                }
-            }
+        license(apache2)
+        developer {
+            name.set("Hansanto")
+            url.set("https://github.com/Hansanto")
+            email.set("anthony.hanson@outlook.fr")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 kotlin.native.cacheKind.linuxX64=none
-kotlin.code.style=official
 kotlin.native.enableKlibsCrossCompilation=true
+kotlin.code.style=official
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1g
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 group=io.github.hansanto
 description=Multiplatform Vault client
 # x-release-please-start-version

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,11 @@
 kotlin.mpp.applyDefaultHierarchyTemplate=false
 kotlin.native.cacheKind.linuxX64=none
 kotlin.code.style=official
+kotlin.native.enableKlibsCrossCompilation=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1g
 group=io.github.hansanto
 description=Multiplatform Vault client
 # x-release-please-start-version
-version=1.6.0
+version=1.6.1-SNAPSHOT
 # x-release-please-end-version

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,5 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 group=io.github.hansanto
 description=Multiplatform Vault client
 # x-release-please-start-version
-version=1.6.1-SNAPSHOT
+version=1.6.0
 # x-release-please-end-version

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
             version("dokka", "2.0.0")
             version("detekt", "1.23.8")
             version("ktlint", "13.1.0")
-            version("publish", "2.0.0")
+            version("deployer", "0.18.0")
 
             plugin("kt-multiplatform", "org.jetbrains.kotlin.multiplatform").versionRef("kotlin")
             plugin("kt-serialization", "org.jetbrains.kotlin.plugin.serialization").versionRef("kotlin")
@@ -37,7 +37,7 @@ dependencyResolutionManagement {
             plugin("detekt", "io.gitlab.arturbosch.detekt").versionRef("detekt")
             plugin("ktlint", "org.jlleitschuh.gradle.ktlint").versionRef("ktlint")
             plugin("resources", "com.goncalossilva.resources").versionRef("resources")
-            plugin("gradle-publish", "io.github.gradle-nexus.publish-plugin").versionRef("publish")
+            plugin("gradle-publish", "io.deepmedia.tools.deployer").versionRef("deployer")
 
             library("kt-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").versionRef("kotlin-serialization")
             library("kt-datetime", "org.jetbrains.kotlinx", "kotlinx-datetime").versionRef("kotlinx-datetime")


### PR DESCRIPTION
See #221

The URL used to publish the library is not usable (https://central.sonatype.org/pages/ossrh-eol/).
We need to migrate to Maven central with the new URL.

Also, this is the opportunity to publish klib files and use Dokka V2